### PR TITLE
Updating CONTRIBUTING.md to reflect proper gulp command arguments.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Once the dependencies are installed, `cd` into the component directory you want 
 | `test`       | Compile tests, run them, and gather code coverage |
 | `all`        | Compile everything and test |
 
-You can also run these gulp tasks from the root directory if you supply an argument. For example, to build the carousel, you can `gulp build --project odo-carousel` or even `gulp build -p carousel`.
+You can also run these gulp tasks from the root directory if you supply an argument. For example, to build the carousel, you can `gulp build --package odo-carousel` or even `gulp build -p carousel`.
 
 ### Project Tasks
 


### PR DESCRIPTION
In the CONTRIBUTING.md file, under the "Package Tests" section, we had written that...

"...you can `gulp build --project odo-carousel` or even `gulp build -p carousel`."

However, the `get-package-directory.js` file seems to be referencing the argument `--package` and not `--project`. The Error that is thrown when you type the command wrong also references `--package`.

This updates the docs to reflect the correct argument for running a gulp command from the root directory.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/odopod/code-library/blob/master/CONTRIBUTING.md#pull-requests
-->
