### PR TITLE
Update README.md - Fixing JS syntax

### DIFF
--- a/packages/odo-expandable/README.md
+++ b/packages/odo-expandable/README.md
@@ -13,7 +13,7 @@ npm install @odopod/odo-expandable --save
 ```js
 import OdoExpandable from '@odopod/odo-expandable';
 
-const instances = OdoExpandable.initializeAll();;
+const instances = OdoExpandable.initializeAll();
 ```
 
 ## [Documentation][permalink]


### PR DESCRIPTION
There's a double `;` in the readme for the JS for Odo-expandable here.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/odopod/code-library/blob/master/CONTRIBUTING.md#pull-requests
-->
